### PR TITLE
Fix FlowJs definitions

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,9 +5,12 @@
 [libs]
 
 [lints]
+ambiguous-object-type=error
 
 [options]
 well_formed_exports=true
 types_first=true
+; Fixes out of shared memory error for Mac Rosetta 2, see https://github.com/facebook/flow/issues/8538
+sharedmemory.heap_size=3221225472
 
 [strict]

--- a/src/errorReporting/RuntimeTypeError.js.flow
+++ b/src/errorReporting/RuntimeTypeError.js.flow
@@ -5,7 +5,7 @@ import type RuntimeTypeErrorItem from './RuntimeTypeErrorItem'
 declare class RuntimeTypeError extends TypeError {
   +errors: RuntimeTypeErrorItem[];
   constructor(errors: RuntimeTypeErrorItem[]): void;
-  formatMessage(options?: { limit?: number }): string;
+  formatMessage(options?: { limit?: number, ... }): string;
 }
 
 export default RuntimeTypeError

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -72,7 +72,7 @@ declare export function readonlyArray<T>(
   elementType: Type<T>
 ): Type<$ReadOnlyArray<T>>
 
-declare export function readonly<T: {}>(type: Type<T>): Type<$ReadOnly<T>>
+declare export function readonly<T: { ... }>(type: Type<T>): Type<$ReadOnly<T>>
 
 declare export function nullLiteral(): Type<null>
 export { nullLiteral as null }
@@ -96,32 +96,32 @@ declare export function string(): Type<string>
 declare export function symbol<T: symbol>(literal: T): Type<T>
 declare export function symbol(): Type<symbol>
 
-type ExtractPropertyTypes<P: { [any]: Type<any> }> = $Exact<
+type ExtractPropertyTypes<P: { [any]: Type<any>, ... }> = $Exact<
   $ObjMap<P, <T: Type<any>>(T) => $PropertyType<T, '__type'>>
 >
-type ExtractOptionalPropertyTypes<P: { [any]: Type<any> }> = $Exact<
+type ExtractOptionalPropertyTypes<P: { [any]: Type<any>, ... }> = $Exact<
   $Rest<ExtractPropertyTypes<P>, { ... }>
 >
 
-declare export function object<R: { [any]: Type<any> }>({|
+declare export function object<R: { [any]: Type<any>, ... }>({|
   required: R,
   exact: false,
 |}): ObjectType<{ ...ExtractPropertyTypes<R>, ... }>
-declare export function object<R: { [any]: Type<any> }>({|
+declare export function object<R: { [any]: Type<any>, ... }>({|
   required: R,
   exact?: true,
 |}): ObjectType<ExtractPropertyTypes<R>>
-declare export function object<S: { [any]: Type<any> }>({|
+declare export function object<S: { [any]: Type<any>, ... }>({|
   optional: S,
   exact: false,
 |}): ObjectType<{ ...ExtractOptionalPropertyTypes<S>, ... }>
-declare export function object<S: { [any]: Type<any> }>({|
+declare export function object<S: { [any]: Type<any>, ... }>({|
   optional: S,
   exact?: true,
 |}): ObjectType<ExtractOptionalPropertyTypes<S>>
 declare export function object<
-  R: { [any]: Type<any> },
-  S: { [any]: Type<any> }
+  R: { [any]: Type<any>, ... },
+  S: { [any]: Type<any>, ... }
 >({|
   required: R,
   optional: S,
@@ -132,8 +132,8 @@ declare export function object<
   ...
 }>
 declare export function object<
-  R: { [any]: Type<any> },
-  S: { [any]: Type<any> }
+  R: { [any]: Type<any>, ... },
+  S: { [any]: Type<any>, ... }
 >({|
   required: R,
   optional: S,
@@ -142,11 +142,11 @@ declare export function object<
   ...ExtractPropertyTypes<R>,
   ...ExtractOptionalPropertyTypes<S>,
 |}>
-declare export function object<R: { [any]: Type<any> }>(
+declare export function object<R: { [any]: Type<any>, ... }>(
   required: R
 ): ObjectType<ExtractPropertyTypes<R>>
 
-type Properties = { [string | number | symbol]: Type<any> }
+type Properties = { [string | number | symbol]: Type<any>, ... }
 
 declare export function record<K: string | number | symbol, V>(
   key: Type<K>,

--- a/src/merge.js.flow
+++ b/src/merge.js.flow
@@ -2,25 +2,25 @@
 
 import Type from './types/Type'
 
-declare export default function merge<T1: {}>(
+declare export default function merge<T1: { ... }>(
   t1: Type<T1>
 ): Type<{| ...$Exact<T1> |}>
-declare export default function merge<T1: {}, T2: {}>(
+declare export default function merge<T1: { ... }, T2: { ... }>(
   t1: Type<T1>,
   t2: Type<T2>
 ): Type<{| ...$Exact<T1>, ...$Exact<T2> |}>
-declare export default function merge<T1: {}, T2: {}, T3: {}>(
+declare export default function merge<T1: { ... }, T2: { ... }, T3: { ... }>(
   t1: Type<T1>,
   t2: Type<T2>,
   t3: Type<T3>
 ): Type<{| ...$Exact<T1>, ...$Exact<T2>, ...$Exact<T3> |}>
-declare export default function merge<T1: {}, T2: {}, T3: {}, T4: {}>(
+declare export default function merge<T1: { ... }, T2: { ... }, T3: { ... }, T4: { ... }>(
   t1: Type<T1>,
   t2: Type<T2>,
   t3: Type<T3>,
   t4: Type<T4>
 ): Type<{| ...$Exact<T1>, ...$Exact<T2>, ...$Exact<T3>, ...$Exact<T4> |}>
-declare export default function merge<T1: {}, T2: {}, T3: {}, T4: {}, T5: {}>(
+declare export default function merge<T1: { ... }, T2: { ... }, T3: { ... }, T4: { ... }, T5: { ... }>(
   t1: Type<T1>,
   t2: Type<T2>,
   t3: Type<T3>,
@@ -34,12 +34,12 @@ declare export default function merge<T1: {}, T2: {}, T3: {}, T4: {}, T5: {}>(
   ...$Exact<T5>,
 |}>
 declare export default function merge<
-  T1: {},
-  T2: {},
-  T3: {},
-  T4: {},
-  T5: {},
-  T6: {}
+  T1: { ... },
+  T2: { ... },
+  T3: { ... },
+  T4: { ... },
+  T5: { ... },
+  T6: { ... }
 >(
   t1: Type<T1>,
   t2: Type<T2>,
@@ -56,13 +56,13 @@ declare export default function merge<
   ...$Exact<T6>,
 |}>
 declare export default function merge<
-  T1: {},
-  T2: {},
-  T3: {},
-  T4: {},
-  T5: {},
-  T6: {},
-  T7: {}
+  T1: { ... },
+  T2: { ... },
+  T3: { ... },
+  T4: { ... },
+  T5: { ... },
+  T6: { ... },
+  T7: { ... }
 >(
   t1: Type<T1>,
   t2: Type<T2>,
@@ -81,14 +81,14 @@ declare export default function merge<
   ...$Exact<T7>,
 |}>
 declare export default function merge<
-  T1: {},
-  T2: {},
-  T3: {},
-  T4: {},
-  T5: {},
-  T6: {},
-  T7: {},
-  T8: {}
+  T1: { ... },
+  T2: { ... },
+  T3: { ... },
+  T4: { ... },
+  T5: { ... },
+  T6: { ... },
+  T7: { ... },
+  T8: { ... }
 >(
   t1: Type<T1>,
   t2: Type<T2>,
@@ -109,4 +109,4 @@ declare export default function merge<
   ...$Exact<T8>,
 |}>
 
-declare export default function merge(...types: Type<{}>[]): Type<{}>
+declare export default function merge(...types: Type<{ ... }>[]): Type<{ ... }>

--- a/src/mergeInexact.js.flow
+++ b/src/mergeInexact.js.flow
@@ -2,30 +2,30 @@
 
 import Type from './types/Type'
 
-declare export default function mergeInexact<T1: {}>(
+declare export default function mergeInexact<T1: { ... }>(
   t1: Type<T1>
 ): Type<{ ...$Exact<T1>, ... }>
-declare export default function mergeInexact<T1: {}, T2: {}>(
+declare export default function mergeInexact<T1: { ... }, T2: { ... }>(
   t1: Type<T1>,
   t2: Type<T2>
 ): Type<{ ...$Exact<T1>, ...$Exact<T2>, ... }>
-declare export default function mergeInexact<T1: {}, T2: {}, T3: {}>(
+declare export default function mergeInexact<T1: { ... }, T2: { ... }, T3: { ... }>(
   t1: Type<T1>,
   t2: Type<T2>,
   t3: Type<T3>
 ): Type<{ ...$Exact<T1>, ...$Exact<T2>, ...$Exact<T3>, ... }>
-declare export default function mergeInexact<T1: {}, T2: {}, T3: {}, T4: {}>(
+declare export default function mergeInexact<T1: { ... }, T2: { ... }, T3: { ... }, T4: { ... }>(
   t1: Type<T1>,
   t2: Type<T2>,
   t3: Type<T3>,
   t4: Type<T4>
 ): Type<{ ...$Exact<T1>, ...$Exact<T2>, ...$Exact<T3>, ...$Exact<T4>, ... }>
 declare export default function mergeInexact<
-  T1: {},
-  T2: {},
-  T3: {},
-  T4: {},
-  T5: {}
+  T1: { ... },
+  T2: { ... },
+  T3: { ... },
+  T4: { ... },
+  T5: { ... }
 >(
   t1: Type<T1>,
   t2: Type<T2>,
@@ -41,12 +41,12 @@ declare export default function mergeInexact<
   ...
 }>
 declare export default function mergeInexact<
-  T1: {},
-  T2: {},
-  T3: {},
-  T4: {},
-  T5: {},
-  T6: {}
+  T1: { ... },
+  T2: { ... },
+  T3: { ... },
+  T4: { ... },
+  T5: { ... },
+  T6: { ... }
 >(
   t1: Type<T1>,
   t2: Type<T2>,
@@ -64,13 +64,13 @@ declare export default function mergeInexact<
   ...
 }>
 declare export default function mergeInexact<
-  T1: {},
-  T2: {},
-  T3: {},
-  T4: {},
-  T5: {},
-  T6: {},
-  T7: {}
+  T1: { ... },
+  T2: { ... },
+  T3: { ... },
+  T4: { ... },
+  T5: { ... },
+  T6: { ... },
+  T7: { ... }
 >(
   t1: Type<T1>,
   t2: Type<T2>,
@@ -90,14 +90,14 @@ declare export default function mergeInexact<
   ...
 }>
 declare export default function mergeInexact<
-  T1: {},
-  T2: {},
-  T3: {},
-  T4: {},
-  T5: {},
-  T6: {},
-  T7: {},
-  T8: {}
+  T1: { ... },
+  T2: { ... },
+  T3: { ... },
+  T4: { ... },
+  T5: { ... },
+  T6: { ... },
+  T7: { ... },
+  T8: { ... }
 >(
   t1: Type<T1>,
   t2: Type<T2>,
@@ -119,4 +119,4 @@ declare export default function mergeInexact<
   ...
 }>
 
-declare export default function mergeInexact(...types: Type<{}>[]): Type<{}>
+declare export default function mergeInexact(...types: Type<{ ... }>[]): Type<{ ... }>

--- a/src/types/MergedObjectType.js.flow
+++ b/src/types/MergedObjectType.js.flow
@@ -2,7 +2,7 @@
 
 import Type from './Type'
 
-declare export default class MergedObjectType<T: {}> extends Type<T> {
+declare export default class MergedObjectType<T: { ... }> extends Type<T> {
   objects: Type<T>[];
   exact: boolean;
 

--- a/src/types/ObjectType.js.flow
+++ b/src/types/ObjectType.js.flow
@@ -4,7 +4,7 @@ import Type from './Type'
 
 import ObjectTypeProperty from './ObjectTypeProperty'
 
-declare class ObjectType<T: {}> extends Type<T> {
+declare class ObjectType<T: { ... }> extends Type<T> {
   properties: ObjectTypeProperty<$Keys<T>, any>[];
   exact: boolean;
 

--- a/src/types/ObjectTypeProperty.js.flow
+++ b/src/types/ObjectTypeProperty.js.flow
@@ -16,7 +16,7 @@ declare class ObjectTypeProperty<
   /**
    * Determine whether the property exists on the given input or its prototype chain.
    */
-  existsOn(input: { [string]: any }): boolean;
+  existsOn(input: { [string]: any, ... }): boolean;
 }
 
 export default ObjectTypeProperty

--- a/src/types/RecordType.js.flow
+++ b/src/types/RecordType.js.flow
@@ -4,6 +4,7 @@ import Type from './Type'
 
 declare class RecordType<K: string | number | symbol, V> extends Type<{
   [K]: V,
+  ...
 }> {
   key: Type<K>;
   value: Type<V>;

--- a/src/types/Type.js.flow
+++ b/src/types/Type.js.flow
@@ -23,7 +23,7 @@ declare class Type<T> {
 
   +acceptsSomeCompositeTypes: boolean;
 
-  assert<V: T>(input: any, prefix?: string, path?: IdentifierPath): V;
+  assert(input: any, prefix?: string, path?: IdentifierPath): T;
 
   validate(input: any, prefix?: string, path?: IdentifierPath): Validation;
 

--- a/src/types/Type.js.flow
+++ b/src/types/Type.js.flow
@@ -27,7 +27,7 @@ declare class Type<T> {
 
   validate(input: any, prefix?: string, path?: IdentifierPath): Validation;
 
-  toString(options?: { formatForMustBe?: boolean }): string;
+  toString(options?: { formatForMustBe?: boolean, ... }): string;
 }
 
 export default Type


### PR DESCRIPTION
**Changes:**
- Make flow definitions compatible with exact-by-default (all flow definitions should use explicit exact/inexact syntax)
- Fix Type definition see https://flow.org/try/#0CYUwxgNghgTiAEkoGdnwCoE8AOICMAPOgHzwDeAUPPANQD6dALjiAFwYDcV8KyIMjAgDV2JABQBLAHbYAro3YBbCQA8QwADTxscAGaqA-O2SMY0gOYBKdkK4BfChVBI48ECuwB7AfF2ypYIwSnlLwUrKKAEb8eGLWGCyE4VH8xI4A9OnwAMoAFp6yEMBuMDDe8Ln8IBRgISbwAG54xqYW8AC8YRHRMLGWAHS8-IxiAOSVEBCeo5ZcTuDQrkioCbgATESklNT0TCyiXNRDApIy8kqq6lo6IPoqRvAmZlJWBxQO8y4I7l4+fgFBEJdFIwNZxUQsDbJHppGp1RiNNYtZ7mDrAnpggbHEbjECTaazChAA


